### PR TITLE
[CMake] Fix build error on Windows due to too long path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ endif()
 # Sofa.Component
 sofa_get_all_targets(all_targets)
 foreach(target ${all_targets})
-    if(target MATCHES "Sofa.Component.*" AND NOT target MATCHES ".*_relocatable_install")
+    if(target MATCHES "Sofa.Component.*" AND NOT target MATCHES ".*_relinst")
         set_target_properties(${target} PROPERTIES FOLDER Sofa.Component) # IDE folder
     endif()
 endforeach()

--- a/Sofa/framework/Config/cmake/SofaMacrosInstall.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosInstall.cmake
@@ -775,10 +775,10 @@ function(sofa_set_project_install_relocatable project_name binary_dir install_di
     # Remove cmakepatch file at each configure
     file(REMOVE "${binary_dir}/cmake_install.cmakepatch")
 
-    set(custom_target ${project_name}_relocatable_install)
+    set(custom_target ${project_name}_relinst)
     get_filename_component(binary_dirname "${binary_dir}" NAME_WE)
     if(binary_dirname AND NOT "${binary_dirname}" STREQUAL "${project_name}")
-        set(custom_target ${project_name}_${binary_dirname}_relocatable_install)
+        set(custom_target ${project_name}_${binary_dirname}_relinst)
     endif()
 
     # Hack to make installed plugin independant and keep the add_subdirectory mechanism
@@ -818,7 +818,7 @@ function(sofa_set_project_install_relocatable project_name binary_dir install_di
                 || true
             )
     endif()
-    set_target_properties(${custom_target} PROPERTIES FOLDER "relocatable_install")
+    set_target_properties(${custom_target} PROPERTIES FOLDER "relinst")
 endfunction()
 
 


### PR DESCRIPTION
Build failed on Windows when attempting to build in a folder that does not have very short name:

12>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(382,5): error MSB3491: Could not write lines to file "x64\Release\SofaGeneralExplicitOdeSolver_relocatable_install\SofaGene.21A0408A.tlog\SofaGeneralExplicitOdeSolver_relocatable_install.lastbuildstate". Path: x64\Release\SofaGeneralExplicitOdeSolver_relocatable_install\SofaGene.21A0408A.tlog\SofaGeneralExplicitOdeSolver_relocatable_install.lastbuildstate exceeds the OS max path limit. The fully qualified file name must be less than 260 characters.  [C:\D\EI-build\SlicerSOFA-build\Sofa-build\applications\collections\deprecated\modules\SofaGeneralExplicitOdeSolver\SofaGeneralExplicitOdeSolver_relocatable_install.vcxproj]
12>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(382,5): error MSB3491: Could not write lines to file "x64\Release\SofaGeneralImplicitOdeSolver_relocatable_install\SofaGene.DB75AD95.tlog\SofaGeneralImplicitOdeSolver_relocatable_install.lastbuildstate". Path: x64\Release\SofaGeneralImplicitOdeSolver_relocatable_install\SofaGene.DB75AD95.tlog\SofaGeneralImplicitOdeSolver_relocatable_install.lastbuildstate exceeds the OS max path limit. The fully qualified file name must be less than 260 characters.  [C:\D\EI-build\SlicerSOFA-build\Sofa-build\applications\collections\deprecated\modules\SofaGeneralImplicitOdeSolver\SofaGeneralImplicitOdeSolver_relocatable_install.vcxproj]

This commit reduces the path length by using "relinst" instead of "relocatable_install". This string appears in the path twice, so the 12-character reduction results in total of 24 character shorter path, which makes it much less likely to run over the path length limit.